### PR TITLE
Add meta viewport tag so chrome dev tools mobile view works properly

### DIFF
--- a/great-idea/index.html
+++ b/great-idea/index.html
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Great Idea!</title>
 
   <link href="https://fonts.googleapis.com/css?family=Bangers|Titillium+Web" rel="stylesheet">

--- a/great-idea/services.html
+++ b/great-idea/services.html
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Great Idea!</title>
 
   <link href="https://fonts.googleapis.com/css?family=Bangers|Titillium+Web" rel="stylesheet">


### PR DESCRIPTION
Without the viewport tag, the mobile device view in Chrome dev tools ignores media queries